### PR TITLE
Add settings method expected by ActionMailer

### DIFF
--- a/lib/mosaic/lyris_mailer.rb
+++ b/lib/mosaic/lyris_mailer.rb
@@ -92,6 +92,11 @@ if ActionMailer::Base.respond_to?(:add_delivery_method)
       def deliver!(mail)
         perform_delivery_lyris(mail)
       end
+
+      # ActionMailer expects this method to be present and to return a hash.
+      def settings
+        {}
+      end
     end
   end
 


### PR DESCRIPTION
When setting default settings for multiple mailers, eg: (default from: test@example.com), an error for missing method definition pops up.